### PR TITLE
Add map boundary proof of concept

### DIFF
--- a/map-boundary-poc/README.md
+++ b/map-boundary-poc/README.md
@@ -1,0 +1,24 @@
+# Map Boundary Proof of Concept
+
+This sample demonstrates a mobile map application built with React Native and a small ASP.NET Core API backend.
+
+## Backend
+
+The backend stores polygon boundaries and pin locations in memory. Run it with `dotnet run`.
+
+```bash
+cd api/MapApi
+dotnet run
+```
+
+## Frontend
+
+The React Native front-end uses `react-native-maps`. Use Expo to run it:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+When you tap inside a polygon, a new pin is created and sent to the backend.

--- a/map-boundary-poc/api/MapApi/MapApi.csproj
+++ b/map-boundary-poc/api/MapApi/MapApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/map-boundary-poc/api/MapApi/Program.cs
+++ b/map-boundary-poc/api/MapApi/Program.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+
+var app = builder.Build();
+
+var polygons = new List<Polygon>();
+var pins = new List<Pin>();
+
+app.MapPost("/api/polygons", (Polygon polygon) =>
+{
+    polygon.Id = Guid.NewGuid();
+    polygons.Add(polygon);
+    return Results.Created($"/api/polygons/{polygon.Id}", polygon);
+});
+
+app.MapGet("/api/polygons", () => polygons);
+
+app.MapPost("/api/pins", (Pin pin) =>
+{
+    pin.Id = Guid.NewGuid();
+    pins.Add(pin);
+    return Results.Created($"/api/pins/{pin.Id}", pin);
+});
+
+app.MapGet("/api/pins", () => pins);
+
+app.Run();
+
+record Polygon
+{
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required List<Coordinate> Points { get; set; }
+}
+
+record Pin
+{
+    public Guid Id { get; set; }
+    public Guid PolygonId { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+}
+
+record Coordinate(double Latitude, double Longitude);

--- a/map-boundary-poc/frontend/App.tsx
+++ b/map-boundary-poc/frontend/App.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
+import MapView, { Marker, Polygon, LatLng, MapPressEvent } from 'react-native-maps';
+import * as Location from 'expo-location';
+import uuid from 'react-native-uuid';
+
+interface PolygonData {
+  id: string;
+  coordinates: LatLng[];
+}
+
+interface PinData {
+  id: string;
+  coordinate: LatLng;
+  polygonId: string;
+}
+
+export default function App() {
+  const [polygons, setPolygons] = useState<PolygonData[]>([]);
+  const [currentCoords, setCurrentCoords] = useState<LatLng[]>([]);
+  const [drawing, setDrawing] = useState(false);
+  const [pins, setPins] = useState<PinData[]>([]);
+
+  const handleMapPress = (e: MapPressEvent) => {
+    const coord = e.nativeEvent.coordinate;
+    if (drawing) {
+      setCurrentCoords([...currentCoords, coord]);
+    } else {
+      const found = polygons.find(p => pointInPolygon(coord, p.coordinates));
+      if (found) {
+        const newPin: PinData = { id: uuid.v4().toString(), coordinate: coord, polygonId: found.id };
+        setPins([...pins, newPin]);
+        fetch('http://localhost:5000/api/pins', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ polygonId: found.id, latitude: coord.latitude, longitude: coord.longitude })
+        }).catch(() => {});
+      }
+    }
+  };
+
+  const completePolygon = () => {
+    if (currentCoords.length >= 3) {
+      const newPoly: PolygonData = { id: uuid.v4().toString(), coordinates: currentCoords };
+      setPolygons([...polygons, newPoly]);
+      setCurrentCoords([]);
+      setDrawing(false);
+      fetch('http://localhost:5000/api/polygons', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Area', points: currentCoords })
+      }).catch(() => {});
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <MapView style={styles.map} onPress={handleMapPress}>
+        {polygons.map(p => (
+          <Polygon key={p.id} coordinates={p.coordinates} strokeColor="black" fillColor="rgba(0,0,0,0.2)" />
+        ))}
+        {pins.map(m => (
+          <Marker key={m.id} coordinate={m.coordinate} />
+        ))}
+        {drawing && currentCoords.length > 0 && (
+          <Polygon coordinates={currentCoords} strokeColor="blue" fillColor="rgba(0,0,255,0.2)" />
+        )}
+      </MapView>
+      <View style={styles.buttons}>
+        {!drawing && <Button title="Add Polygon" onPress={() => setDrawing(true)} />}
+        {drawing && <Button title="Finish" onPress={completePolygon} />}
+      </View>
+    </View>
+  );
+}
+
+function pointInPolygon(point: LatLng, vs: LatLng[]) {
+  let inside = false;
+  for (let i = 0, j = vs.length - 1; i < vs.length; j = i++) {
+    const xi = vs[i].latitude, yi = vs[i].longitude;
+    const xj = vs[j].latitude, yj = vs[j].longitude;
+
+    const intersect = ((yi > point.longitude) !== (yj > point.longitude)) &&
+      (point.latitude < (xj - xi) * (point.longitude - yi) / (yj - yi) + xi);
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  map: { flex: 1 },
+  buttons: { position: 'absolute', bottom: 20, left: 20, right: 20 }
+});

--- a/map-boundary-poc/frontend/package.json
+++ b/map-boundary-poc/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "map-boundary-poc",
+  "private": true,
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "react-native-maps": "^1.3.2",
+    "react-native-uuid": "^2.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add Map Boundary PoC with React Native frontend and ASP.NET Core backend
- frontend lets users draw polygons and drop pins within them
- backend exposes minimal API endpoints to store polygons and pins

## Testing
- `dotnet --version` *(fails: command not found)*
